### PR TITLE
Add feature excludedNamespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.1.1] - 2021-10-19
 
 - SelfLink is deprecated and disabled since kubernetes 1.20 [#1](https://github.com/blakelead/nsinjector/pull/1)
+- Add support for excludedNamespaces in CRD
 
 ## [v0.1.0] - 2020-06-20
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ metadata:
 spec:
   namespaces:
   - dev-.*
+  excludedNamespaces:
+  - dev-excluded-.* 
   resources:
   - |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -69,6 +71,7 @@ spec:
 ```
 
 - `namespaces`:  a list of namespace names or regex
+- `excludedNamespaces`: a list of namespace names or regex to be excluded
 - `resources`: a list of any Kubernetes resources
 
 ## Contributing

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nsinjector-controller
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
-appVersion: v0.1.0
+version: 0.1.1
+appVersion: v0.1.1

--- a/deploy/helm/crds/crd-v1beta1.yaml
+++ b/deploy/helm/crds/crd-v1beta1.yaml
@@ -28,6 +28,11 @@ spec:
               type: array
               items:
                 type: string
+            excludedNamespaces:
+              description: 'Namespaces is a list of namespaces names or regex that will be excluded to be injected.'
+              type: array
+              items:
+                type: string
             resources:
               description: 'Resources is the map of resources to be injected.'
               type: array

--- a/deploy/helm/templates/namespaceresourcesinjector.yaml
+++ b/deploy/helm/templates/namespaceresourcesinjector.yaml
@@ -9,6 +9,10 @@ spec:
   - |-
 {{ . | indent 4 }}
 {{- end }}
+  excludedNamespaces:
+{{- range $injector.excludedNamespaces }}
+  - |-
+{{ . | indent 4 }}
   resources:
 {{- range  $injector.resources }}
   - |-

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -16,6 +16,8 @@ injectors:
   - name: injector1
     namespaces:
       - dev-*
+    excludedNamespaces:
+      - dev-exclude-.*
     resources:
       - |
         apiVersion: rbac.authorization.k8s.io/v1
@@ -45,6 +47,8 @@ injectors:
   - name: injector2
     namespaces:
       - stg-*
+    excludedNamespaces:
+      - stg-excluded-.*
     resources:
       - |
         apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/k8s/crd/namespaceresourcesinjector-crd-1.16.yaml
+++ b/deploy/k8s/crd/namespaceresourcesinjector-crd-1.16.yaml
@@ -27,6 +27,11 @@ spec:
                   type: array
                   items:
                     type: string
+                excludedNamespaces:
+                  description: 'Namespaces is a list of namespaces names or regex that will be excluded to be injected.'
+                  type: array
+                  items:
+                    type: string
                 resources:
                   description: 'Resources is the map of resources to be injected.'
                   type: array

--- a/deploy/k8s/crd/namespaceresourcesinjector-crd.yaml
+++ b/deploy/k8s/crd/namespaceresourcesinjector-crd.yaml
@@ -28,6 +28,11 @@ spec:
               type: array
               items:
                 type: string
+            excludedNamespaces:
+              description: 'Namespaces is a list of namespaces names or regex that will be excluded to be injected.'
+              type: array
+              items:
+                type: string
             resources:
               description: 'Resources is the map of resources to be injected.'
               type: array

--- a/deploy/k8s/namespaceresourcesinjector.yaml
+++ b/deploy/k8s/namespaceresourcesinjector.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   namespaces:
   - dev-.*
+  excludedNamespaces:
+  - dev-excluded.*
   resources:
   - |
     apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/apis/namespaceresourcesinjector/v1alpha1/types.go
+++ b/pkg/apis/namespaceresourcesinjector/v1alpha1/types.go
@@ -21,6 +21,11 @@ type NamespaceResourcesInjector struct {
 }
 
 func (nri *NamespaceResourcesInjector) CanInject(namespace string) bool {
+    for _, item := range nri.Spec.ExcludedNamespaces {
+		if match, _ := regexp.MatchString(item, namespace); match {
+			return false
+		}
+	}
 	for _, item := range nri.Spec.Namespaces {
 		if match, _ := regexp.MatchString(item, namespace); match {
 			return true
@@ -40,6 +45,7 @@ func (nri *NamespaceResourcesInjector) Injected(namespace string) bool {
 
 // NamespaceResourcesInjectorSpec is the spec for a NamespaceResourcesInjector resource
 type NamespaceResourcesInjectorSpec struct {
+    ExcludedNamespaces []string `json:"excludedNamespaces"`
 	Namespaces []string `json:"namespaces"`
 	Resources  []string `json:"resources"`
 }

--- a/pkg/apis/namespaceresourcesinjector/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/namespaceresourcesinjector/v1alpha1/zz_generated.deepcopy.go
@@ -92,6 +92,11 @@ func (in *NamespaceResourcesInjectorSpec) DeepCopyInto(out *NamespaceResourcesIn
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExcludedNamespaces != nil {
+		in, out := &in.ExcludedNamespaces, &out.ExcludedNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make([]string, len(*in))


### PR DESCRIPTION
"excludedNamespaces" will ignore namespaces that are included by the "namespaces" value.

For example if you define regex "^dev-.*" you can, exclude namespace "dev-exclude" by adding "^dev-exclude.*" to excludeNamespaces.