### PR TITLE
Fixed error in jinja "EOF" and updated to CRD to api v1

### DIFF
--- a/deploy/helm/crds/crd-v1beta1.yaml
+++ b/deploy/helm/crds/crd-v1beta1.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: namespaceresourcesinjectors.blakelead.com
@@ -15,37 +15,37 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-  validation:
-    openAPIV3Schema:
-      description: 'NamespaceResourcesInjector describes the resources that the controller will inject in specified namespaces.'
-      type: object
-      properties:
-        spec:
+      schema:
+        openAPIV3Schema:
+          description: 'NamespaceResourcesInjector describes the resources that the controller will inject in specified namespaces.'
           type: object
           properties:
-            namespaces:
-              description: 'Namespaces is a list of namespaces names or regex that will be matched to be injected.'
-              type: array
-              items:
-                type: string
-            excludedNamespaces:
-              description: 'Namespaces is a list of namespaces names or regex that will be excluded to be injected.'
-              type: array
-              items:
-                type: string
-            resources:
-              description: 'Resources is the map of resources to be injected.'
-              type: array
-              items:
-                type: string
-        status:
-          type: object
-          properties:
-            injectedNamespaces:
-              description: 'InjectedNamespaces is a list of namespaces this injector injected its resources in.'
-              type: array
-              items:
-                type: string
+            spec:
+              type: object
+              properties:
+                namespaces:
+                  description: 'Namespaces is a list of namespaces names or regex that will be matched to be injected.'
+                  type: array
+                  items:
+                    type: string
+                excludedNamespaces:
+                  description: 'Namespaces is a list of namespaces names or regex that will be excluded to be injected.'
+                  type: array
+                  items:
+                    type: string
+                resources:
+                  description: 'Resources is the map of resources to be injected.'
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                injectedNamespaces:
+                  description: 'InjectedNamespaces is a list of namespaces this injector injected its resources in.'
+                  type: array
+                  items:
+                    type: string
   additionalPrinterColumns:
     - name: InjectedNamespaces
       type: string

--- a/deploy/helm/templates/namespaceresourcesinjector.yaml
+++ b/deploy/helm/templates/namespaceresourcesinjector.yaml
@@ -13,6 +13,7 @@ spec:
 {{- range $injector.excludedNamespaces }}
   - |-
 {{ . | indent 4 }}
+{{- end }}
   resources:
 {{- range  $injector.resources }}
   - |-


### PR DESCRIPTION
Hello,

I have been running a RKE2 Kubernetes version 1.23.0 and found that this project is not supported. To correct this error and got it working in my HA cluster was the following changes:

- Changed APIVersion of CRD from v1beta1 to v1
- Changed the validation to the new schema to the key "schema"
- "validation" is no longer global to the APISchema, moved to "schema"
- Fixed a Jinja error where a "range" did not close and caused error "EOF"

Tested and working